### PR TITLE
修复 Star History 图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ ID：*(VIP账号 ：**Tast**；密码：**111111** )*
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=TastSong/CrazyCar)
+![Star History Chart](https://star-history.dera.page/svg?repos=TastSong/CrazyCar)
 
 ## 赞助
 

--- a/README_en.md
+++ b/README_en.md
@@ -192,7 +192,7 @@ You can submit questions in the  [pull requests](https://github.com/TastSong/Cra
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=TastSong/CrazyCar)
+![Star History Chart](https://star-history.dera.page/svg?repos=TastSong/CrazyCar)
 
 ## Sponsor
 


### PR DESCRIPTION
当前的 Star History 图表因 GitHub Stargazer API 限制而无法正常显示，已更换为可正常工作的数据源并更新了 README 与 README_en 中的图表链接。